### PR TITLE
Brofiler Verification now errors on any output

### DIFF
--- a/DevNullPlayer/Program.cs
+++ b/DevNullPlayer/Program.cs
@@ -10,10 +10,26 @@ namespace DevNullPlayer
 		{
 			using (var input = File.OpenRead(args[0])) {
 				var parser = new DemoParser(input);
-				#if DEBUG
-				parser.TickDone += (sender, e) => Console.Write(".");;
-				#endif
 				parser.ParseHeader ();
+
+				#if DEBUG
+				if (args.Length >= 2) {
+					// progress reporting requested
+					using (var progressWriter = new StreamWriter(args[1]) { AutoFlush = false }) {
+						int lastPercentage = -1;
+						while (parser.ParseNextTick()) {
+							var newProgress = (int)(parser.ParsingProgess * 100);
+							if (newProgress != lastPercentage) {
+								progressWriter.Write(lastPercentage = newProgress);
+								progressWriter.Flush();
+							}
+						}
+					}
+
+					return;
+				}
+				#endif
+
 				parser.ParseToEnd ();
 			}
 		}

--- a/DevNullPlayer/Program.cs
+++ b/DevNullPlayer/Program.cs
@@ -15,7 +15,8 @@ namespace DevNullPlayer
 				#if DEBUG
 				if (args.Length >= 2) {
 					// progress reporting requested
-					using (var progressWriter = new StreamWriter(args[1]) { AutoFlush = false }) {
+					using (var progressFile = File.OpenWrite(args[1]))
+					using (var progressWriter = new StreamWriter(progressFile) { AutoFlush = false }) {
 						int lastPercentage = -1;
 						while (parser.ParseNextTick()) {
 							var newProgress = (int)(parser.ParsingProgess * 100);

--- a/ci/brofiler.py
+++ b/ci/brofiler.py
@@ -52,7 +52,8 @@ def invoke(script, dem, report_progress=False):
         fd = rready[0]
         chunk = os.read(fd, 4096)
         if report_progress and fd is pipe_rfd:
-            print('\r' + str(chunk), end='')
+            print('\r%03d%%' % (int(chunk),), end='')
+            sys.stdout.flush()
         elif len(chunk) == 0:
             # end of stream
             pending.remove(fd)

--- a/ci/brofiler.py
+++ b/ci/brofiler.py
@@ -31,9 +31,7 @@ def set_status(sha, state, desc, ctx, url=None):
                         headers={'Authorization': 'token ' + GH_TOKEN}, data=json.dumps(request).encode('utf-8'))
     return res.text
 
-dotcnt = 0
-def invoke(script, dem, echo_dots=False):
-    global dotcnt
+def invoke(script, dem, report_progress=False):
     pipe_rfd, pipe_wfd = os.pipe()
     p = subprocess.Popen(
         ['/bin/bash', script, dem, str(pipe_wfd)],
@@ -49,20 +47,19 @@ def invoke(script, dem, echo_dots=False):
     stderr_chunks = []
     stdout_rfd, stderr_rfd = p.stdout.fileno(), p.stderr.fileno()
     pending = [pipe_rfd, stdout_rfd, stderr_rfd]
-    while len(pending) > 1 or pipe_rfd not in pending: # wait for all except pipe
+    while len(pending) > 1:
         rready, _, _ = select.select(pending, [], [])
         fd = rready[0]
         chunk = os.read(fd, 4096)
-        if echo_dots and chunk == '.':
-            dotcnt += 1
-            print(str(dotcnt), end='\r')
+        if report_progress and fd is pipe_rfd:
+            print('\r' + str(chunk), end='')
         elif len(chunk) == 0:
             # end of stream
             pending.remove(fd)
         else:
             (pipe_chunks if fd is pipe_rfd else stdout_chunks if fd is stdout_rfd else stderr_chunks).append(chunk.decode('utf-8'))
     retval = p.wait()
-    print('%s return value %d' % (dem, retval))
+    print('\r%s return value %d' % (dem, retval))
     err_text = ''.join(stderr_chunks)
     out_text = ''.join(stdout_chunks)
     pipe_text = ''.join(pipe_chunks)
@@ -94,7 +91,7 @@ elif sys.argv[1] == 'verify':
     # now run verification
     for dem in demos:
         retval, out_text, err_text, _ = invoke('ci/verify.sh', dem, True) # pipe not in use
-        if retval == 0:
+        if retval == 0 and not out_text and not err_text:
             set_status(COMMIT, 'pending', 'Verify success', dem)
         else:
             how_many_failures += 1

--- a/ci/verify.sh
+++ b/ci/verify.sh
@@ -1,6 +1,7 @@
 set -eu
 
 demofile="$1"
+output_pipe="$2"
 
 # Bitstream-Debugging, no profiling.
-mono --optimize=all DevNullPlayer/bin/Debug/DevNullPlayer.exe "testdemos/$demofile"
+mono --optimize=all DevNullPlayer/bin/Debug/DevNullPlayer.exe "testdemos/$demofile" "/dev/fd/$output_pipe"


### PR DESCRIPTION
Previously, verification would always be reported as success when 0 was returned, even if output was produced (e.g. assertion failures).